### PR TITLE
Add Windows platform support

### DIFF
--- a/.github/workflows/windows-support-ci.yml
+++ b/.github/workflows/windows-support-ci.yml
@@ -1,0 +1,90 @@
+name: Windows Support CI
+
+on:
+  push:
+    branches: [ feature/windows-support ]
+  pull_request:
+    branches: [ feature/windows-support ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Cross-Platform Test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rust: stable
+          - os: macos-latest
+            rust: stable
+          - os: windows-latest
+            rust: stable
+
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
+
+      - name: Verify submodule branch
+        run: |
+          echo "Checking submodule branch..."
+          git config -f .gitmodules --get submodule.ht-core.branch
+          git submodule status
+        shell: bash
+
+      - name: List ht-core contents
+        run: ls -la ht-core/
+        shell: bash
+          
+      - name: Show Rust info
+        run: |
+          echo "Rust version:"
+          rustc --version
+          echo "Cargo version:"  
+          cargo --version
+          echo "Targets:"
+          rustup target list --installed
+        shell: bash
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.rust }}-
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Lint with clippy
+        run: cargo clippy --package ht-mcp --all-targets
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose
+        env:
+          RUSTFLAGS: "--cfg ci"
+
+      - name: Build release binary
+        run: cargo build --release

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ht-core"]
 	path = ht-core
 	url = https://github.com/memextech/ht.git
+	branch = windows-support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "uuid",
+ "windows",
 ]
 
 [[package]]
@@ -704,7 +705,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1827,16 +1828,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1844,6 +1879,17 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1869,11 +1915,30 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/src/ht_integration/native_session_manager.rs
+++ b/src/ht_integration/native_session_manager.rs
@@ -203,7 +203,7 @@ mod tests {
 
         // Use platform-agnostic default shell
         // NativeSessionManager.create_session already handles platform detection
-        
+
         // Create a session
         let create_result = manager
             .create_session(CreateSessionArgs {

--- a/src/ht_integration/native_session_manager.rs
+++ b/src/ht_integration/native_session_manager.rs
@@ -201,17 +201,13 @@ mod tests {
     async fn test_native_session_manager() {
         let manager = NativeSessionManager::new();
 
-        // Choose shell based on platform
-        let shell = if cfg!(windows) {
-            "powershell.exe"
-        } else {
-            "bash"
-        };
-
+        // Use platform-agnostic default shell
+        // NativeSessionManager.create_session already handles platform detection
+        
         // Create a session
         let create_result = manager
             .create_session(CreateSessionArgs {
-                command: Some(vec![shell.to_string()]),
+                command: None, // Use default shell for platform
                 enable_web_server: Some(false),
             })
             .await
@@ -232,17 +228,13 @@ mod tests {
             .unwrap()
             .contains("session"));
 
-        // Test command execution - use platform-specific echo command
-        let echo_command = if cfg!(windows) {
-            "Write-Host test"
-        } else {
-            "echo test"
-        };
-        
+        // Test command execution with a simple command that works cross-platform
+        // We'll just use a simple directory listing command since it works everywhere
         let exec_result = manager
             .execute_command(ExecuteCommandArgs {
                 session_id: session_id.clone(),
-                command: echo_command.to_string(),
+                // Use a command that works on all platforms without explicit conditionals
+                command: "pwd || cd".to_string(), // pwd on Unix, cd on Windows
             })
             .await
             .unwrap();

--- a/src/ht_integration/native_webserver.rs
+++ b/src/ht_integration/native_webserver.rs
@@ -74,7 +74,7 @@ impl NativeHtManager {
         // Start HT process
         // Use a function to get the platform-specific HT binary name
         let ht_binary = get_ht_binary_name();
-        
+
         let mut child = Command::new(ht_binary)
             .args(&ht_args)
             .stdin(Stdio::piped())

--- a/src/ht_integration/session_manager.rs
+++ b/src/ht_integration/session_manager.rs
@@ -390,7 +390,7 @@ fn create_winsize(cols: u16, rows: u16) -> Winsize {
             ws_ypixel: 0,
         }
     }
-    
+
     #[cfg(windows)]
     {
         Winsize {

--- a/src/ht_integration/session_manager.rs
+++ b/src/ht_integration/session_manager.rs
@@ -51,21 +51,9 @@ impl SessionManager {
         let (command_tx, mut command_rx) = mpsc::channel::<SessionCommand>(1024);
         let (clients_tx, mut clients_rx) = mpsc::channel(1);
 
-        // Set up the terminal size with platform-specific fields
-        #[cfg(unix)]
-        let size = Winsize {
-            ws_col: 120,
-            ws_row: 40,
-            ws_xpixel: 0,
-            ws_ypixel: 0,
-        };
-        
-        #[cfg(windows)]
-        let size = Winsize {
-            ws_col: 120,
-            ws_row: 40,
-        };
-        
+        // Create a platform-agnostic terminal size
+        // Using a helper function to maintain a clean interface
+        let size = create_winsize(120, 40);
         let cols = size.ws_col as usize;
         let rows = size.ws_row as usize;
 
@@ -387,5 +375,27 @@ fn parse_key_to_input_seq(key: &str) -> ht_core::command::InputSeq {
         "F12" => InputSeq::Standard("\x1b[24~".to_string()),
         // Everything else is treated as literal text
         _ => InputSeq::Standard(key.to_string()),
+    }
+}
+
+/// Creates a Winsize struct with platform-appropriate fields
+/// This function abstracts away platform differences in the Winsize struct
+fn create_winsize(cols: u16, rows: u16) -> Winsize {
+    #[cfg(unix)]
+    {
+        Winsize {
+            ws_col: cols,
+            ws_row: rows,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        }
+    }
+    
+    #[cfg(windows)]
+    {
+        Winsize {
+            ws_col: cols,
+            ws_row: rows,
+        }
     }
 }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -54,13 +54,19 @@ pub struct CloseSessionArgs {
 
 // Schema generation functions
 pub fn create_session_schema() -> Value {
+    let default_command = if cfg!(windows) {
+        "[\"powershell.exe\"]"
+    } else {
+        "[\"bash\"]"
+    };
+    
     json!({
         "type": "object",
         "properties": {
             "command": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Command to run in the terminal (default: [\"bash\"])"
+                "description": format!("Command to run in the terminal (default: {})", default_command)
             },
             "enableWebServer": {
                 "type": "boolean",

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -59,7 +59,7 @@ pub fn create_session_schema() -> Value {
     } else {
         "[\"bash\"]"
     };
-    
+
     json!({
         "type": "object",
         "properties": {

--- a/test-brew-manual.sh
+++ b/test-brew-manual.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "🧪 Testing Homebrew formula manually with local binary..."
+
+# Create a temporary directory for our test tap
+TEST_TAP_DIR="/tmp/homebrew-test-tap"
+rm -rf "$TEST_TAP_DIR"
+mkdir -p "$TEST_TAP_DIR/Formula"
+
+# Build the binary if not already built
+if [ ! -f "target/release/ht-mcp" ]; then
+    echo "🔨 Building release binary..."
+    cargo build --release
+fi
+
+# Create a local file URL for the binary
+BINARY_PATH="$(pwd)/target/release/ht-mcp"
+BINARY_SHA=$(shasum -a 256 "$BINARY_PATH" | cut -d' ' -f1)
+
+echo "📝 Creating test formula with local binary..."
+cat > "$TEST_TAP_DIR/Formula/ht-mcp.rb" << EOF
+class HtMcp < Formula
+  desc "Headless Terminal MCP Server - Control terminal sessions via Model Context Protocol"
+  homepage "https://github.com/memextech/ht-mcp"
+  version "0.1.3-test-local"
+  url "file://$BINARY_PATH"
+  sha256 "$BINARY_SHA"
+
+  def install
+    bin.install "ht-mcp"
+  end
+
+  test do
+    # Test that the binary exists and shows help
+    assert_match "Pure Rust MCP server", shell_output("#{bin}/ht-mcp --help 2>&1")
+  end
+end
+EOF
+
+echo "✅ Formula created!"
+echo "📄 Formula content:"
+cat "$TEST_TAP_DIR/Formula/ht-mcp.rb"
+echo ""
+
+# Check if we can add this tap
+echo "🔧 Adding temporary tap..."
+if brew tap-new test/local || true; then
+    echo "Tap created or already exists"
+fi
+
+# Copy our formula to the tap
+LOCAL_TAP_DIR="$(brew --repository)/Library/Taps/test/homebrew-local"
+if [ -d "$LOCAL_TAP_DIR" ]; then
+    cp "$TEST_TAP_DIR/Formula/ht-mcp.rb" "$LOCAL_TAP_DIR/Formula/"
+    echo "✅ Formula copied to local tap"
+    
+    echo "🧪 Testing formula installation..."
+    # Uninstall if already installed
+    brew uninstall test/local/ht-mcp 2>/dev/null || true
+    
+    # Install from our local tap
+    if brew install test/local/ht-mcp; then
+        echo "✅ Installation successful!"
+        
+        echo "🧪 Testing installed binary..."
+        if ht-mcp --help | grep -q "Pure Rust MCP server"; then
+            echo "✅ Binary test successful!"
+        else
+            echo "❌ Binary test failed"
+            exit 1
+        fi
+        
+        echo "🧪 Running brew test..."
+        if brew test test/local/ht-mcp; then
+            echo "✅ Brew test successful!"
+        else
+            echo "❌ Brew test failed"
+            exit 1
+        fi
+        
+        echo ""
+        echo "🎉 ALL TESTS PASSED!"
+        echo "✅ Homebrew formula works correctly"
+        echo ""
+        echo "Clean up with: brew uninstall test/local/ht-mcp && brew untap test/local"
+    else
+        echo "❌ Installation failed"
+        exit 1
+    fi
+else
+    echo "❌ Could not create local tap directory"
+    exit 1
+fi


### PR DESCRIPTION
## Windows Support Implementation

This PR adds full Windows platform support to ht-mcp:

### Key Changes
- Updated ht-core submodule to use windows-support branch
- Added platform-specific code for Windows terminal handling
- Created proper abstractions for cross-platform compatibility
- Added dedicated helper functions to encapsulate platform differences:
  - create_winsize() - Handles terminal size structure differences
  - get_default_shell() - PowerShell on Windows, bash on Unix
  - get_ht_binary_name() - ht.exe on Windows, ht on Unix
- Improved port selection logic (5000-6000 range on Windows)
- Fixed formatting issues for CI compliance

### CI Improvements
- Added dedicated Windows CI workflow
- Ensured tests can run on all platforms
- Made integration tests platform-agnostic
- Fixed code formatting across all files

This completes Windows support implementation and paves the way for 0.1.1 release.

Resolves #2