### PR TITLE
fix: Update web server port range from 3000-4000 to 3618-3999

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ HT session created successfully!
 
 Session ID: abc123-def456-789...
 
-🌐 Web server enabled! View live terminal at: http://127.0.0.1:3000
+🌐 Web server enabled! View live terminal at: http://127.0.0.1:3618
 ```
 
 ```text

--- a/src/ht_integration/session_manager.rs
+++ b/src/ht_integration/session_manager.rs
@@ -189,8 +189,10 @@ impl SessionManager {
     }
 
     /// Find an available port for the webserver
+    /// Uses port range 3618-3999 to avoid conflicts with common development servers
+    /// (Next.js: 3000, React: 3001, etc.)
     async fn find_available_port(&self) -> Result<u16> {
-        for port in 3000..4000 {
+        for port in 3618..3999 {
             if let Ok(listener) = TcpListener::bind(format!("127.0.0.1:{}", port)) {
                 drop(listener);
                 return Ok(port);

--- a/tests/unit_response_formatting.rs
+++ b/tests/unit_response_formatting.rs
@@ -8,7 +8,7 @@ fn test_create_session_response_format() {
     let mock_response = json!({
         "sessionId": "test-session-123",
         "webServerEnabled": true,
-        "webServerUrl": "http://127.0.0.1:3000"
+        "webServerUrl": "http://127.0.0.1:3618"
     });
 
     let formatted = format_create_session_response(&mock_response);
@@ -16,7 +16,7 @@ fn test_create_session_response_format() {
     assert!(formatted.contains("HT session created successfully!"));
     assert!(formatted.contains("Session ID: test-session-123"));
     assert!(formatted.contains("🌐 Web server enabled!"));
-    assert!(formatted.contains("http://127.0.0.1:3000"));
+    assert!(formatted.contains("http://127.0.0.1:3618"));
 }
 
 #[test]


### PR DESCRIPTION
- Change port range to avoid conflicts with common development servers
- Next.js typically uses port 3000, React uses 3001, etc.
- New range 3618-3999 provides 381 available ports for sessions
- Updated documentation and tests to reflect new port range
- Added explanatory comment in find_available_port function

Fixes #12

🤖 Generated with [Memex](https://memex.tech)