### PR TITLE
feat: Add --port CLI option for web server port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ ht-mcp
 
 # With debug logging
 ht-mcp --debug
+
+# With specific web server port
+ht-mcp --port 4000
 ```
 
 Once configured in your MCP client:

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,10 @@ struct Cli {
     /// Server name for MCP identification
     #[arg(long, default_value = "ht-mcp-server")]
     name: String,
+
+    /// Web server port (if not specified, auto-discovers available port in range 3618-3999)
+    #[arg(long)]
+    port: Option<u16>,
 }
 
 #[tokio::main]
@@ -48,9 +52,14 @@ async fn main() -> anyhow::Result<()> {
     tracing::subscriber::set_global_default(subscriber)?;
 
     info!("Starting HT MCP Server v{}", env!("CARGO_PKG_VERSION"));
+    if let Some(port) = cli.port {
+        info!("Web server port configured: {}", port);
+    } else {
+        info!("Web server port will be auto-discovered in range 3618-3999");
+    }
 
     // Create MCP server
-    let mut server = HtMcpServer::new();
+    let mut server = HtMcpServer::new_with_port_config(cli.port);
 
     info!("HT MCP Server created successfully");
     info!("Server info: {:?}", server.server_info());

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -29,6 +29,17 @@ impl HtMcpServer {
         }
     }
 
+    pub fn new_with_port_config(web_port_config: Option<u16>) -> Self {
+        Self {
+            session_manager: Arc::new(Mutex::new(SessionManager::new_with_port_config(web_port_config))),
+            server_info: ServerInfo {
+                name: "ht-mcp-server".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+            },
+            call_counter: AtomicU64::new(0),
+        }
+    }
+
     pub fn server_info(&self) -> &ServerInfo {
         &self.server_info
     }


### PR DESCRIPTION
## Summary

This PR adds a new `--port` CLI option that allows users to specify a fixed port for the web server instead of relying on auto-discovery. This provides deterministic port assignment while maintaining full backward compatibility.

### Key Features

- **Standard CLI Convention**: Uses `--port` following common tool patterns (nginx, redis, etc.)
- **Deterministic Ports**: Specify exact port for development, Docker, and CI/CD environments
- **Backward Compatible**: Default behavior unchanged - still auto-discovers in range 3618-3999
- **Error Handling**: Clear error messages if configured port is unavailable
- **Informative Logging**: Shows which port mode is active on startup

### Usage Examples

```bash
# Auto-discovery (existing default behavior)
ht-mcp

# Specific port
ht-mcp --port 4000

# Combined with other options
ht-mcp --port 3618 --debug --name my-server
```

### Technical Implementation

- **CLI Argument**: Added `--port <PORT>` option with clap validation
- **Port Selection Logic**: Try configured port first, fallback to auto-discovery
- **SessionManager**: Extended to accept optional port configuration
- **Error Handling**: Fails fast if configured port is unavailable
- **Logging**: Clear indication of port configuration mode

### Benefits

1. **Docker-Friendly**: Easy port mapping with deterministic ports
2. **Development**: No more hunting for which port the server chose
3. **CI/CD**: Predictable port assignment for automated testing
4. **Backward Compatible**: Existing usage patterns continue to work
5. **Following Standards**: Uses conventional `--port` argument name

### Files Changed

- `src/main.rs` - CLI argument definition and initialization
- `src/mcp/server.rs` - Port config constructor
- `src/ht_integration/session_manager.rs` - Port selection logic
- `README.md` - Usage documentation

### Testing

- ✅ All existing tests pass (no regressions)
- ✅ Manual testing verified both auto-discovery and specific port work
- ✅ Error handling tested with unavailable ports
- ✅ Help text displays correctly

This feature addresses a common need for deterministic port assignment while preserving the existing auto-discovery behavior that works well for development scenarios.